### PR TITLE
Add PCAP export option, make script/container public-facing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:latest
 
 RUN apk --update --no-cache add python3-dev git tcpdump gcc g++ libxml2 libxslt-dev tshark
 RUN pip3 install --upgrade pip
-RUN git clone https://github.com/ChristopherJHart/floodlight.git /floodlight
+RUN mkdir /floodlight
+ADD . /floodlight
 RUN pip3 install -r /floodlight/requirements.txt
 CMD [ "python3", "-u", "/floodlight/floodlight.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
 FROM alpine:latest
 
-RUN export PS4='\t '
-ARG GITLAB_TOKEN
-ENV GITLAB_TOKEN=$GITLAB_TOKEN
-
-RUN export http_proxy=http://proxy.esl.cisco.com:80/
-RUN export https_proxy=https://proxy.esl.cisco.com:80/
 RUN apk --update --no-cache add python3-dev git tcpdump gcc g++ libxml2 libxslt-dev tshark
 RUN pip3 install --upgrade pip
-RUN git clone https://gitlab-ci-token:$GITLAB_TOKEN@gitlab-sjc.cisco.com/docker-projects/Floodlight.git /floodlight
+RUN git clone https://github.com/ChristopherJHart/floodlight.git /floodlight
 RUN pip3 install -r /floodlight/requirements.txt
 CMD [ "python3", "-u", "/floodlight/floodlight.py" ]

--- a/floodlight.py
+++ b/floodlight.py
@@ -64,6 +64,7 @@ def main():
         log.info("\n%s", pformat(filters))
     else:
         log.error("[SETUP] NX-OS startup-config file not detected! Using empty filters...")
+        filters = {}
     
     if os.environ.get("CAPTURE_TIME") is not None:
         capture_time = int(os.environ.get("CAPTURE_TIME"))
@@ -76,7 +77,8 @@ def main():
     subprocess.Popen(tshark_cmd, shell=True).wait()
     packets = rdpcap("/tmp/floodlight.pcapng")
     log.info("[CAPTURE] Packet capture finished! %s packets in capture", len(packets))
-    unexpected_packets = [packet for idx, packet in enumerate(packets, 1) if not expected_packet(filters, packet, idx)]
+    if filters:
+        unexpected_packets = [packet for idx, packet in enumerate(packets, 1) if not expected_packet(filters, packet, idx)]
     log.info("[UNEXPECTED] Number of unexpected packets: %s", len(unexpected_packets))
     unique_packets = {}
     for pkt in unexpected_packets:

--- a/floodlight.py
+++ b/floodlight.py
@@ -92,9 +92,7 @@ def main():
     log.info("{0!s: >15} RESULTS {0!s: <15}".format("="*5))
     for packet in sorted_list:
         log.info("%s bytes (%s packets) | %s", "{:,}".format(int(packet["flow_size"])), "{:,}".format(len(packet["pkts"])), summarize_packet(packet["pkts"][0]))
-    log.info("EXPORT? %s", os.environ.get("EXPORT"))
     if os.environ.get("EXPORT") is not None:
-        log.info("[WRITE-PCAP] Writing unexpected packets to PCAP...")
         wrpcap(os.environ.get("EXPORT"), unexpected_packets)
         log.info("[WRITE-PCAP] Successfully wrote unexpected packets to PCAP at %s", os.environ.get("EXPORT"))
 

--- a/floodlight.py
+++ b/floodlight.py
@@ -92,6 +92,7 @@ def main():
     log.info("{0!s: >15} RESULTS {0!s: <15}".format("="*5))
     for packet in sorted_list:
         log.info("%s bytes (%s packets) | %s", "{:,}".format(int(packet["flow_size"])), "{:,}".format(len(packet["pkts"])), summarize_packet(packet["pkts"][0]))
+    log.info("EXPORT? %s", os.environ.get("EXPORT"))
     if os.environ.get("EXPORT") is not None:
         log.info("[WRITE-PCAP] Writing unexpected packets to PCAP...")
         wrpcap(os.environ.get("EXPORT"), unexpected_packets)

--- a/floodlight.py
+++ b/floodlight.py
@@ -80,7 +80,7 @@ def main():
     if filters:
         unexpected_packets = [packet for idx, packet in enumerate(packets, 1) if not expected_packet(filters, packet, idx)]
     else:
-        unexpected_packs = packets
+        unexpected_packets = packets
     log.info("[UNEXPECTED] Number of unexpected packets: %s", len(unexpected_packets))
     unique_packets = {}
     for pkt in unexpected_packets:

--- a/floodlight.py
+++ b/floodlight.py
@@ -79,6 +79,8 @@ def main():
     log.info("[CAPTURE] Packet capture finished! %s packets in capture", len(packets))
     if filters:
         unexpected_packets = [packet for idx, packet in enumerate(packets, 1) if not expected_packet(filters, packet, idx)]
+    else:
+        unexpected_packs = packets
     log.info("[UNEXPECTED] Number of unexpected packets: %s", len(unexpected_packets))
     unique_packets = {}
     for pkt in unexpected_packets:

--- a/floodlight.py
+++ b/floodlight.py
@@ -93,8 +93,9 @@ def main():
     for packet in sorted_list:
         log.info("%s bytes (%s packets) | %s", "{:,}".format(int(packet["flow_size"])), "{:,}".format(len(packet["pkts"])), summarize_packet(packet["pkts"][0]))
     if os.environ.get("EXPORT") is not None:
+        log.info("[WRITE-PCAP] Writing unexpected packets to PCAP...")
         wrpcap(os.environ.get("EXPORT"), unexpected_packets)
-        log.info("[WRITE-PCAP] Successfully wrote unexpected files to PCAP at %s", os.environ.get("EXPORT"))
+        log.info("[WRITE-PCAP] Successfully wrote unexpected packets to PCAP at %s", os.environ.get("EXPORT"))
 
 def get_packet_length(pkt):
     try:


### PR DESCRIPTION
This pull request adds the ability for users to export unexpected packets to a PCAP file for further review in a utility such as Wireshark. Furthermore, this pull request cleans up the script and Dockerfile to be external-facing, removing all references to Cisco internal resources.